### PR TITLE
Issue#3 - iOS MissingPluginException - hasTorch

### DIFF
--- a/ios/Classes/SwiftTorchCompatPlugin.swift
+++ b/ios/Classes/SwiftTorchCompatPlugin.swift
@@ -24,7 +24,7 @@ public class SwiftTorchCompatPlugin: NSObject, FlutterPlugin {
                 turnOff()
                 result(true)
             }
-        } else if (call.method == "turnOn") {
+        } else if (call.method == "hasTorch") {
             result(hasTorch())
         } else {
             result(FlutterMethodNotImplemented)


### PR DESCRIPTION
- updated call.method string match value from `turnOn` to `hasTorch`

fixes #3 